### PR TITLE
added brew and run installs for pandoc and pandoc-crossref

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,9 +15,12 @@ jobs:
       
       - name: Download Source Files
         uses: actions/checkout@v2
-      
+
+      - name: Enable Homebrew # uses this fix because gh removed brew from path. Look into other options
+        uses: raviqqe/enable-homebrew@v0.1.0
+
       - name: Setup Pandoc
-        uses: r-lib/actions/setup-pandoc@v2
+        run: brew install pandoc pandoc-crossref
       
       - name: Setup TinyTeX
         uses: r-lib/actions/setup-tinytex@v2


### PR DESCRIPTION
this adds back homebrew and a hack to add brew to the path. We should in the future determine if this is the correct path. 